### PR TITLE
Change DB_FILENAME to sfs.db

### DIFF
--- a/src/checks.h
+++ b/src/checks.h
@@ -17,7 +17,7 @@
 
 #include "sqlite.h"
 
-constexpr std::string_view DB_FILENAME = "s3gw.db";
+constexpr std::string_view DB_FILENAME = "sfs.db";
 
 /* Fix - This is an abstract datatype representing an executable action to fix
  * an incosistency in the filesystem or metadata database.


### PR DESCRIPTION
Since https://github.com/aquarist-labs/ceph/pull/245 rgw/sfs uses
'sfs.db' instead of 's3gw.db'

Signed-off-by: Marcel Lauhoff <marcel.lauhoff@suse.com>
